### PR TITLE
Serve frontend from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ export GEMINI_API_KEY="YOUR_KEY_HERE"
 uvicorn backend.server:app --reload
 ```
 
-5. Open `frontend/index.html` in your browser and interact with the app.
+5. Open [http://localhost:8000](http://localhost:8000) in your browser and interact with the app.
 
 ## Notes
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 from fastapi import FastAPI, UploadFile, File, Form, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 from .transcriber import process_transcription, TranscriptTurn
 
@@ -57,3 +58,7 @@ async def transcribe(
     transcript_text = "\n\n".join([f"{t.speaker.upper()}:\t\t{t.text}" for t in turns])
     encoded = base64.b64encode(docx_bytes).decode()
     return JSONResponse({"transcript": transcript_text, "docx_base64": encoded})
+
+frontend_dir = os.path.join(os.path.dirname(__file__), "..", "frontend")
+app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")
+


### PR DESCRIPTION
## Summary
- mount the `frontend` directory as a static site in `backend.server`
- update README to open the app via the running FastAPI server

## Testing
- `pip install -r requirements.txt`
- `uvicorn backend.server:app --port 8000 --lifespan off` *(fails: GEMINI_API_KEY not set, so set dummy env var)*
- `curl -s http://127.0.0.1:8000 | head`
- `curl -I http://127.0.0.1:8000/api/transcribe`

------
https://chatgpt.com/codex/tasks/task_e_6840eb880afc83208baeb16f41082c7b